### PR TITLE
Renaming and region updates.

### DIFF
--- a/docs/cleaning-up.rst
+++ b/docs/cleaning-up.rst
@@ -38,22 +38,26 @@ Cleaning up your development environment
 
         The CloudFormation templates in :ref:`Environment Setup` create three CloudFormation stacks to clean up.
 
-        Use the `CloudFormation console <https://eu-west-1.console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks?filter=active>`_ to clean up
-        the stacks created for your Cloud9 setup.
+        Use the |cloud9_console_link| to clean up the stacks created for your Cloud9 setup.
+
+        .. |cloud9_console_link| raw:: html
+
+            <a href="https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks?filter=active" target="_blank">
+            CloudFormation console</a>
 
         They'll be named as follows. Delete them in this order:
 
-        #. ``aws-cloud9-ReinventSid345Cloud9-<string>``
-        #. ``MySid345Cloud9Env``
-        #. ``MySid345BaseEnv``
+        #. ``aws-cloud9-BusyEngineersEncryptionSDK-<string>``
+        #. ``BusyEngineersSdkCloud9``
+        #. ``BusyEngineersSdkBase``
 
     .. group-tab:: Manual
 
-        Open `the EC2 console for eu-west-1
-        <https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#Instances:sort=instanceId>`_.
+        Open `the EC2 console for us-east-2
+        <https://us-east-2.console.aws.amazon.com/ec2/v2/home?region=us-east-2#Instances:sort=instanceId>`_.
 
         Terminate the instance you created earlier.
 
-        Go to `the IAM console's Roles section <https://console.aws.amazon.com/iam/home?region=eu-west-1#/roles>`_.
+        Go to `the IAM console's Roles section <https://console.aws.amazon.com/iam/home?region=us-east-2#/roles>`_.
 
-        Remove the ``sid345-admin`` role.
+        Remove the ``busy-engineers-workshop-admin`` role.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 """Sphinx configuration."""
 from datetime import datetime
 
-project = "re:Invent SID345 Workshop"
+project = "A Busy Engineer's Guide to the AWS Encryption SDK"
 
 source_suffix = ".rst"  # The suffix of source filenames.
 master_doc = "index"  # The master toctree document.
@@ -28,5 +28,5 @@ htmlhelp_basename = "%sdoc" % project
 autosummary_generate = True
 
 rst_prolog = """
-.. |region| replace:: eu-west-1
+.. |region| replace:: us-east-2
 """

--- a/docs/environment-setup.rst
+++ b/docs/environment-setup.rst
@@ -16,23 +16,45 @@ Here are instructions to prepare your environment to run the workshop.
         We have created CloudFormation templates that will set up a Cloud9 workspace that has the necessary prerequisites installed
         and uses a role with the necessary permissions.
 
+        The setup is split across two stacks: the Initial Stack, for basic resources, and the Cloud9 stack, for an IDE.
+
         **Initial Stack**
 
-        If you are using a Qwiklabs account then the initial CloudFormation stack has already been created.
-        You can continue to **Cloud9 Stack**.
+        Sign into the Console and launch the initial CloudFormation stack.
 
-        If you are manually setting up an account, you need to sign into the Console and launch the initial CloudFormation stack.
+        |launch_initial_cfn|
+
+        .. |launch_initial_cfn| raw:: html
+
+            <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/new?stackName=BusyEngineersSdkBase&templateURL=https://s3.amazonaws.com/busy-engineers-guide.reinvent-workshop.com/cloudformation/busy-engineers-encryption-sdk.yaml"
+                target="_blank">
 
         .. image:: ./images/cloudformation-launch-stack.png
-            :target: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?stackName=MySid345BaseEnv&templateURL=https://s3.amazonaws.com/sid345.reinvent-workshop.com/cloudformation/reinvent-sid345.yaml
+
+        |launch_initial_cfn_link_close|
+
+        .. |launch_initial_cfn_link_close| raw:: html
+
+            </a>
 
         **Cloud9 Stack**
 
-        Once the initial CloudFormation stack deployment is complete, you need to launch the Cloud9 CloudFormation stack.
+        Wait for the initial CloudFormation stack deployment to complete, then launch the Cloud9 CloudFormation stack.
+
+        |launch_cloud9_cfn|
+
+        .. |launch_cloud9_cfn| raw:: html
+
+            <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/new?stackName=BusyEngineersSdkCloud9&templateURL=https://s3.amazonaws.com/busy-engineers-guide.reinvent-workshop.com/cloudformation/busy-engineers-encryption-sdk-cloud9.yaml"
+                target="_blank">
 
         .. image:: ./images/cloudformation-launch-stack.png
-            :target: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?stackName=MySid345Cloud9Env&templateURL=https://s3.amazonaws.com/sid345.reinvent-workshop.com/cloudformation/reinvent-sid345-cloud9.yaml
 
+        |launch_cloud9_cfn_link_close|
+
+        .. |launch_cloud9_cfn_link_close| raw:: html
+
+            </a>
 
 
     .. group-tab:: Manual
@@ -49,7 +71,7 @@ Here are instructions to prepare your environment to run the workshop.
         * Python 3.6 (we specifically need 3.6 to build binaries for Lambda) (Python only)
         * tox (Python only)
 
-        The :ref:`EC2 quickstart` section will walk you through setting these up.
+        The EC2 quickstart section will walk you through setting these up.
 
         **AWS credentials**
 
@@ -85,18 +107,18 @@ Here are instructions to prepare your environment to run the workshop.
             we recommend doing this in a test account.
 
         #. Log in to the AWS Console.
-        #. Go to `the IAM console's Roles section <https://console.aws.amazon.com/iam/home?region=eu-west-1#/roles>`_.
+        #. Go to `the IAM console's Roles section <https://console.aws.amazon.com/iam/home?region=us-east-2#/roles>`_.
         #. Click the "Create Role" button.
         #. Under "Choose the service that will use this role", select "EC2",
            then select "EC2" for the use case and proceed to the next page.
         #. Select ``AdministratorAccess``, and proceed to the next page.
-        #. Set some easy-to-remember name for the role such as "sid345-admin".
+        #. Set some easy-to-remember name for the role such as "busy-engineers-workshop-admin".
 
         Now that you have a role created, we'll deploy a Linux instance to use as our
         launching point.
 
-        Open `the EC2 console for eu-west-1
-        <https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#Instances:sort=instanceId>`_.
+        Open `the EC2 console for us-east-2
+        <https://us-east-2.console.aws.amazon.com/ec2/v2/home?region=us-east-2#Instances:sort=instanceId>`_.
 
         If you have not launched any instances here before, you'll first need to either
         `create a new key pair
@@ -110,14 +132,14 @@ Here are instructions to prepare your environment to run the workshop.
         #. Click the blue 'Launch Instance' button.
         #. Select the 'Amazon Linux AMI 2018.03.0 (HVM), SSD Volume Type' AMI.
         #. Click 'Configure Instance Details' and make sure 'Auto-assign Public IP' is **Enabled**.
-        #. **In 'IAM Role', select the role you created above.** ("sid345-admin", or your preferred name)
+        #. **In 'IAM Role', select the role you created above.** ("busy-engineers-workshop-admin", or your preferred name)
         #. Click 'Review and Launch'.
         #. Click 'Launch'.
         #. In the provided dialog, select the keypair you just created or imported.
         #. Click 'Launch Instances'.
 
         Once the instance launches, you'll see it in the `instance list
-        <https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#Instances>`_.
+        <https://us-east-2.console.aws.amazon.com/ec2/v2/home?region=us-east-2#Instances>`_.
 
         Copy the public DNS hostname. You can then log into this instance using
         username ``ec2-user`` and the keypair you created before.
@@ -126,7 +148,7 @@ Here are instructions to prepare your environment to run the workshop.
         <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html>`_ for more detail.
 
 
-.. _Prerequisites Installation
+.. _Prerequisites Installation:
 
 Prerequisites Installation
 ==========================
@@ -135,26 +157,38 @@ Prerequisites Installation
 
     .. group-tab:: Cloud9 (Java)
 
+        Use the console to find your |cloud9_java|.
+
+        .. |cloud9_java| raw:: html
+
+            <a href="https://us-east-2.console.aws.amazon.com/cloud9/home?region=us-east-2" target="_blank">Cloud9 IDE</a>
+
         Once you're logged in to the Cloud9 IDE, use our utility script to prepare your language environment.
 
         .. code-block:: bash
 
-            cd reinvent-sid345-workshop-sample
+            cd busy-engineers-encryption-sdk
             git checkout utilities
             ./prep-java.sh
 
         .. attention::
 
             Cloud9 should automatically check out the git repository when you activate the IDE. Sometimes this script
-            does not run. If you do not have a copy of ``reinvent-sid345-workshop-sample``, close your IDE tab and reopen it.
+            does not run. If you do not have a copy of ``busy-engineers-encryption-sdk``, close your IDE tab and reopen it.
 
     .. group-tab:: Cloud9 (Python)
+
+        Use the console to find your |cloud9_python|.
+
+        .. |cloud9_python| raw:: html
+
+            <a href="https://us-east-2.console.aws.amazon.com/cloud9/home?region=us-east-2" target="_blank">Cloud9 IDE</a>
 
         Once you're logged in to the Cloud9 IDE, use our utility script to prepare your language environment.
 
         .. code-block:: bash
 
-            cd reinvent-sid345-workshop-sample
+            cd busy-engineers-encryption-sdk
             git checkout utilities
             ./prep-python.sh
             . ~/.bashrc
@@ -162,7 +196,7 @@ Prerequisites Installation
         .. attention::
 
             Cloud9 should automatically check out the git repository when you activate the IDE. Sometimes this script
-            does not run. If you do not have a copy of ``reinvent-sid345-workshop-sample``, close your IDE tab and reopen it.
+            does not run. If you do not have a copy of ``busy-engineers-encryption-sdk``, close your IDE tab and reopen it.
 
     .. group-tab:: Manual (Java)
 
@@ -223,8 +257,8 @@ Prerequisites Installation
 
         .. code-block:: bash
 
-            git clone https://github.com/aws-samples/reinvent-sid345-workshop-sample.git
-            cd reinvent-sid345-workshop-sample
+            git clone https://github.com/aws-samples/busy-engineers-encryption-sdk.git
+            cd busy-engineers-encryption-sdk
 
         To edit files, the ``nano`` editor is built-in. You can also install or use another editor of your choice,
         such as ``vim`` or ``emacs``.
@@ -247,8 +281,8 @@ Prerequisites Installation
 
         .. code-block:: bash
 
-            git clone https://github.com/aws-samples/reinvent-sid345-workshop-sample.git
-            cd reinvent-sid345-workshop-sample
+            git clone https://github.com/aws-samples/busy-engineers-encryption-sdk.git
+            cd busy-engineers-encryption-sdk
 
         To edit files, the ``nano`` editor is built-in. You can also install or use another editor of your choice,
         such as ``vim`` or ``emacs``.

--- a/docs/exercises/0-explore.rst
+++ b/docs/exercises/0-explore.rst
@@ -66,7 +66,7 @@ the example application.
 Our build tools automatically build the Lambda, use AWS CloudFormation to deploy AWS resources, and
 uploads the built application as a Lambda function. The initial deployment typically takes 3-5
 minutes to complete. You can monitor the progress of the deployment on the `CloudFormation console
-<https://eu-west-1.console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks?filter=active>`_.
+<https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks?filter=active>`_.
 
 When the deployment completes, you'll see output like this.
 
@@ -77,13 +77,13 @@ When the deployment completes, you'll see output like this.
         .. code-block:: bash
 
             [INFO] Deployment successful.
-            [INFO] Deployment URL: https://EXAMPLE.execute-api.eu-west-1.amazonaws.com/test/
+            [INFO] Deployment URL: https://EXAMPLE.execute-api.us-east-2.amazonaws.com/test/
 
     .. group-tab:: Python
 
         .. code-block:: bash
 
-            Endpoint available at: https://EXAMPLE.execute-api.eu-west-1.amazonaws.com/test/
+            Endpoint available at: https://EXAMPLE.execute-api.us-east-2.amazonaws.com/test/
 
 To go to the sample application, open the URL in the output.
 
@@ -106,11 +106,11 @@ Cleaning up
 -----------
 
 When you're done with the workshop, you can shut down the application and clean
-up its AWS resources using the instructions in the :ref:`Clean up` section.
+up its AWS resources using the instructions in the :ref:`Cleaning up` section.
 
 This destroys all AWS resources related to the demo application except for the
 CloudWatch Log groups that AWS Lambda generated. You can delete those log groups from
-`the CloudWatch console <https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logs:>`_.
+`the CloudWatch console <https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logs:>`_.
 
 .. _Exploring the example application:
 
@@ -172,7 +172,7 @@ deploying them.
     .. group-tab:: Python
 
         We've created an ``EncryptDecrypt`` placeholder class for your encryption and data encoding logic.
-        You'll see the class under ``src/reinvent_sid345/encrypt_decrypt.py``.
+        You'll see the class under ``src/busy_engineers_workshop/encrypt_decrypt.py``.
         After you've worked through this workshop, this class will convert between plaintext and ciphertext.
 
 
@@ -236,7 +236,7 @@ Detailed steps
         We'll use the builtin ``base64`` module.
 
         .. code-block:: python
-           :lineno-start: 18
+           :lineno-start: 17
 
            import base64
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
 
 .. _Main:
 
-###########################################################
-SID345: The Busy Engineer's Guide to the AWS Encryption SDK
-###########################################################
+#################################################
+A Busy Engineer's Guide to the AWS Encryption SDK
+#################################################
 
 In this workshop, you will add encryption and decryption features to a simple web application that
 sends form data over Amazon SQS.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Use us-east-2
* Switch to generic Busy Engineer's Guide name
* Update CFN link targets
* Make CFN and Cloud9 setup/teardown links pop in a new window rather than navigating away from instructions
* Small cleanup to render warnings etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
