### PR TITLE
fix group tab issue by locking dependency version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=1.3.0
 alabaster
-sphinx_tabs
+sphinx_tabs==1.1.8


### PR DESCRIPTION
*Description of changes:*
lock sphinx_tabs to 1.1.8 pending https://github.com/djungelorm/sphinx-tabs/issues/31

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
