### PR TITLE
updated node version to 8.1 (exercise2-java)

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -155,7 +155,7 @@ Resources:
       Handler: index.redirect
       MemorySize: 128
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Timeout: 5
   RedirectPermissions:
     Type: 'AWS::Lambda::Permission'


### PR DESCRIPTION
*Issue #, if available:*
#111
*Description of changes:*
Lambda is incompatible with node version 6.1 so updating to 8.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.