### PR TITLE
Make the Lambda role match more generic.

### DIFF
--- a/deploy-plugin/src/main/java/sample/AssignGrantPlugin.java
+++ b/deploy-plugin/src/main/java/sample/AssignGrantPlugin.java
@@ -63,7 +63,7 @@ public class AssignGrantPlugin extends AbstractMojo {
             
             // Get the Lambda-associated role to be our grantee principal
             List<Role> allRoles = iamClient.listRoles().getRoles();
-            List<Role> filteredRoles = allRoles.stream().filter(r -> r.getRoleName().contains("busy-engineers-ee-iam-LambdaRole-")).collect(Collectors.toList());
+            List<Role> filteredRoles = allRoles.stream().filter(r -> r.getRoleName().contains("Lambda")).collect(Collectors.toList());
             if (filteredRoles.isEmpty()) {
                 throw new MojoFailureException("Unable to find Lambda role ARN to assign grant.");
             }


### PR DESCRIPTION
Return to the broad match -- might overmatch but temporary fix.

See https://github.com/aws-samples/busy-engineers-encryption-sdk/issues/209

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
