### PR TITLE
Make the Lambda role match more generic.

### DIFF
--- a/build-tools/assign_grant.sh
+++ b/build-tools/assign_grant.sh
@@ -25,7 +25,7 @@ echo "* Assigning Grants *"
 echo "********************"
 
 account=$(aws sts get-caller-identity --query 'Account' --output text)
-account_arn=$(aws iam list-roles | grep "busy-engineers-ee-iam-LambdaRole-" | grep "arn" | awk '{print $2}' | tr -d \" | tr -d ",")
+account_arn=$(aws iam list-roles | grep "Lambda" | grep "arn" | awk '{print $2}' | tr -d \" | tr -d ",")
 alias="alias/busy-engineers-workshop-us-west-2-key"
 arn="arn:aws:kms:us-west-2:$account:$alias"
 key_id=$(aws kms describe-key --region "us-west-2" --key-id $arn --query 'KeyMetadata.KeyId' --output text)


### PR DESCRIPTION
*Issue #, if available:* #209

*Description of changes:*

Return to the broad match -- might overmatch but temporary fix.

See https://github.com/aws-samples/busy-engineers-encryption-sdk/issues/209

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
