### PR TITLE
Update node version to 12.x (exercise5-finished-java)

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -152,7 +152,7 @@ Resources:
       Handler: index.redirect
       MemorySize: 128
       Role: !ImportValue "busy-engineers-workshop-LambdaRole"
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 5
   RedirectPermissions:
     Type: 'AWS::Lambda::Permission'


### PR DESCRIPTION
*Issue #, if available:*
Lambda is incompatible with node version 8.10 so I am updated to version 12.x
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
